### PR TITLE
feat: Use 'latest' release for macOS download link

### DIFF
--- a/src/views/Desktop.vue
+++ b/src/views/Desktop.vue
@@ -20,7 +20,7 @@
 
         <div class="download-section">
           <a
-            href="https://github.com/azooKey/azooKey-Desktop/releases/download/v0.1.1/azooKey-release-signed.pkg"
+            href="https://github.com/azooKey/azooKey-Desktop/releases/latest/download/azooKey-release-signed.pkg"
             class="download-btn"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
## Issues

Closes  #16

## 変更点

macOS版のダウンロードリンクが常に最新リリースのリンクとなるよう `releases/latest/download/` の形式に変更しました。

## 前提条件

今後のリリースでもアセット名が `azooKey-release-signed.pkg` であることを前提としています。

## 参考

[Linking to releases - GitHub Docs](https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases#linking-to-the-latest-release)