### PR TITLE
fix: 一部ページで直アクセス時にタイトルが重複する問題を修正

### DIFF
--- a/src/views/Contact.vue
+++ b/src/views/Contact.vue
@@ -32,22 +32,6 @@ const description = 'azooKeyに関するお問い合わせをお寄せくださ�
 const image = 'https://azookey.com/static/og-image.png'
 const title = 'お問い合わせ | azooKey - 自由自在なキーボードアプリ'
 
-useHead({
-  title: () => 'お問い合わせ |'
-})
-
-useSeoMeta({
-  ogTitle: () => title,
-  twitterTitle: () => title,
-
-  description: () => description,
-  ogDescription: () => description,
-  twitterDescription: () => description,
-
-  ogImage: () => image,
-  twitterImage: () => image
-})
-
 export default defineComponent({
   // eslint-disable-next-line vue/multi-word-component-names
   name: 'Contact',
@@ -57,6 +41,24 @@ export default defineComponent({
     SectionTitle,
     ArticleContainer,
     MiniHeader
+  },
+
+  setup() {
+    useHead({
+      title: () => 'お問い合わせ |'
+    })
+
+    useSeoMeta({
+      ogTitle: () => title,
+      twitterTitle: () => title,
+
+      description: () => description,
+      ogDescription: () => description,
+      twitterDescription: () => description,
+
+      ogImage: () => image,
+      twitterImage: () => image
+    })
   },
 
   data() {

--- a/src/views/Desktop.vue
+++ b/src/views/Desktop.vue
@@ -107,7 +107,7 @@ const description =
   'iOS向けキーボードアプリ「azooKey」のmacOS版は、ニューラルかな漢字変換エンジンを搭載した本格派日本語入力です。'
 const image = 'https://azookey.com/static/og-image.png'
 
-useHead({ title })
+useHead({ title, titleTemplate: '' })
 
 useSeoMeta({
   ogTitle: () => title,

--- a/src/views/Desktop.vue
+++ b/src/views/Desktop.vue
@@ -107,7 +107,7 @@ const description =
   'iOS向けキーボードアプリ「azooKey」のmacOS版は、ニューラルかな漢字変換エンジンを搭載した本格派日本語入力です。'
 const image = 'https://azookey.com/static/og-image.png'
 
-useHead({ title, titleTemplate: '' })
+useHead({ title: 'macOS版 |' })
 
 useSeoMeta({
   ogTitle: () => title,

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -52,23 +52,6 @@ const description =
   'azooKeyは強力なカスタマイズ機能を搭載した日本語入力キーボードです。最先端の高精度変換システム「Zenzai」を搭載し、完全オフラインで動作します。ライブ変換、着せ替え、ユーザ辞書など、快適な入力のための機能もしっかりサポートしています。普段使う日本語タブをカスタマイズするカスタムキー機能とオリジナルの配列のキーボードを作るカスタムタブ機能でどこまでも自由にカスタマイズができます。'
 const image = 'https://azookey.com/static/og-image.png'
 
-useHead({
-  title: 'azooKey - 自由自在なキーボードアプリ',
-  titleTemplate: ''
-})
-
-useSeoMeta({
-  ogTitle: () => title,
-  twitterTitle: () => title,
-
-  description: () => description,
-  ogDescription: () => description,
-  twitterDescription: () => description,
-
-  ogImage: () => image,
-  twitterImage: () => image
-})
-
 export default defineComponent({
   // eslint-disable-next-line vue/multi-word-component-names, vue/no-reserved-component-names
   name: 'Main',
@@ -79,6 +62,25 @@ export default defineComponent({
     HeroHeader,
     ArticleContainer,
     MiniHeader
+  },
+
+  setup() {
+    useHead({
+      title: 'azooKey - 自由自在なキーボードアプリ',
+      titleTemplate: ''
+    })
+
+    useSeoMeta({
+      ogTitle: () => title,
+      twitterTitle: () => title,
+
+      description: () => description,
+      ogDescription: () => description,
+      twitterDescription: () => description,
+
+      ogImage: () => image,
+      twitterImage: () => image
+    })
   },
 
   data() {

--- a/src/views/OpenSource.vue
+++ b/src/views/OpenSource.vue
@@ -134,22 +134,6 @@ const description =
 const image = 'https://azookey.com/static/og-image.png'
 const title = 'オープンソース | azooKey - 自由自在なキーボードアプリ'
 
-useHead({
-  title: () => 'オープンソース |'
-})
-
-useSeoMeta({
-  ogTitle: () => title,
-  twitterTitle: () => title,
-
-  description: () => description,
-  ogDescription: () => description,
-  twitterDescription: () => description,
-
-  ogImage: () => image,
-  twitterImage: () => image
-})
-
 export default defineComponent({
   name: 'OpenSource',
   components: {
@@ -158,6 +142,23 @@ export default defineComponent({
     ArticleContainer,
     GitHubButton,
     MiniHeader
+  },
+  setup() {
+    useHead({
+      title: () => 'オープンソース |'
+    })
+
+    useSeoMeta({
+      ogTitle: () => title,
+      twitterTitle: () => title,
+
+      description: () => description,
+      ogDescription: () => description,
+      twitterDescription: () => description,
+
+      ogImage: () => image,
+      twitterImage: () => image
+    })
   }
 })
 </script>

--- a/src/views/PrivacyPolicy.vue
+++ b/src/views/PrivacyPolicy.vue
@@ -51,22 +51,6 @@ const description = 'プライバシーポリシー'
 const image = 'https://azookey.com/static/og-image.png'
 const title = 'プライバシーポリシー | azooKey - 自由自在なキーボードアプリ'
 
-useHead({
-  title: () => 'プライバシーポリシー |'
-})
-
-useSeoMeta({
-  ogTitle: () => title,
-  twitterTitle: () => title,
-
-  description: () => description,
-  ogDescription: () => description,
-  twitterDescription: () => description,
-
-  ogImage: () => image,
-  twitterImage: () => image
-})
-
 export default defineComponent({
   name: 'PrivacyPolicy',
 
@@ -75,6 +59,24 @@ export default defineComponent({
     SectionTitle,
     ArticleContainer,
     MiniHeader
+  },
+
+  setup() {
+    useHead({
+      title: () => 'プライバシーポリシー |'
+    })
+
+    useSeoMeta({
+      ogTitle: () => title,
+      twitterTitle: () => title,
+
+      description: () => description,
+      ogDescription: () => description,
+      twitterDescription: () => description,
+
+      ogImage: () => image,
+      twitterImage: () => image
+    })
   }
 })
 </script>

--- a/src/views/QA.vue
+++ b/src/views/QA.vue
@@ -30,22 +30,6 @@ const description = 'azooKeyに関するQ&Aをまとめています。'
 const image = 'https://azookey.com/static/og-image.png'
 const title = 'Q&A | azooKey - 自由自在なキーボードアプリ'
 
-useHead({
-  title: () => 'Q&A |'
-})
-
-useSeoMeta({
-  ogTitle: () => title,
-  twitterTitle: () => title,
-
-  description: () => description,
-  ogDescription: () => description,
-  twitterDescription: () => description,
-
-  ogImage: () => image,
-  twitterImage: () => image
-})
-
 export default defineComponent({
   name: 'QA',
 
@@ -54,6 +38,24 @@ export default defineComponent({
     SectionTitle,
     ArticleContainer,
     MiniHeader
+  },
+
+  setup() {
+    useHead({
+      title: () => 'Q&A |'
+    })
+
+    useSeoMeta({
+      ogTitle: () => title,
+      twitterTitle: () => title,
+
+      description: () => description,
+      ogDescription: () => description,
+      twitterDescription: () => description,
+
+      ogImage: () => image,
+      twitterImage: () => image
+    })
   },
 
   data() {

--- a/src/views/TermsOfService.vue
+++ b/src/views/TermsOfService.vue
@@ -88,22 +88,6 @@ const description = '利用規約'
 const image = 'https://azookey.com/static/og-image.png'
 const title = '利用規約 | azooKey - 自由自在なキーボードアプリ'
 
-useHead({
-  title: '利用規約 |'
-})
-
-useSeoMeta({
-  ogTitle: () => title,
-  twitterTitle: () => title,
-
-  description: () => description,
-  ogDescription: () => description,
-  twitterDescription: () => description,
-
-  ogImage: () => image,
-  twitterImage: () => image
-})
-
 export default defineComponent({
   name: 'TermsOfService',
 
@@ -112,6 +96,24 @@ export default defineComponent({
     SectionTitle,
     ArticleContainer,
     MiniHeader
+  },
+
+  setup() {
+    useHead({
+      title: '利用規約 |'
+    })
+
+    useSeoMeta({
+      ogTitle: () => title,
+      twitterTitle: () => title,
+
+      description: () => description,
+      ogDescription: () => description,
+      twitterDescription: () => description,
+
+      ogImage: () => image,
+      twitterImage: () => image
+    })
   }
 })
 </script>


### PR DESCRIPTION
## 現象

以下のページに直接アクセスすると、ブラウザのタブなどに表示されるタイトルでサイト名が繰り返し出力される。
ただし、一度別なページ（e.g. `/OpenSource`）に遷移してから、ヘッダーやフッター内のリンクを経由して当該ページに戻ると、重複が解消される。

- https://azookey.com/
  - `azooKey - 自由自在なキーボードアプリ azooKey - 自由自在なキーボードアプリ`
- https://azookey.com/macOS
  - `macOS版 | azooKey - 自由自在なキーボードアプリ azooKey - 自由自在なキーボードアプリ`

## 原因

- 各ページで `useHead` / `useSeoMeta` を `setup()` の外で呼び出していたため、head 情報の登録タイミングやページ遷移時の扱いが想定とずれ、直アクセス時のタイトルに影響したと考えられる。
- `Desktop.vue` では `useHead` に渡す `title` にすでにサイト名が含まれていたため、App 側の `titleTemplate` と組み合わさってサイト名が二重に表示されていた。

## 変更内容

- `Main.vue` / `OpenSource.vue` / `Contact.vue` / `QA.vue` / `PrivacyPolicy.vue` / `TermsOfService.vue`
  - Composable は `setup()` もしくは `<script setup>` の中で呼び出す必要があるため、`useHead` / `useSeoMeta` の呼び出しをモジュールトップレベルから `setup()` 内に移動した
- `Desktop.vue`
  - 他ページと同じく、`useHead` では`macOS版 |` のみを指定するようにした

## 動作確認

1. 各ページに直接アクセスして、タイトルが重複して出力されていないことを確認する
2. 別ページを経由して戻った際も、正しいタイトルが表示されることを確認する